### PR TITLE
✨ 회원가입/로그인 관련 DAO 구현 반

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	testImplementation 'org.mockito:mockito-core:5.2.0'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/barowoori/foodpinbackend/common/dto/CommonResponse.java
+++ b/src/main/java/com/barowoori/foodpinbackend/common/dto/CommonResponse.java
@@ -1,0 +1,18 @@
+package com.barowoori.foodpinbackend.common.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+@Getter
+@Builder
+public class CommonResponse {
+    @Builder.Default
+    private String id = UUID.randomUUID().toString();
+    @Builder.Default
+    private LocalDateTime createAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    private Object data;
+}

--- a/src/main/java/com/barowoori/foodpinbackend/config/QueryDslConfig.java
+++ b/src/main/java/com/barowoori/foodpinbackend/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.barowoori.foodpinbackend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/member/command/domain/exception/MemberErrorCode.java
+++ b/src/main/java/com/barowoori/foodpinbackend/member/command/domain/exception/MemberErrorCode.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum MemberErrorCode implements ErrorCode {
     MEMBER_NICKNAME_EMPTY(HttpStatus.BAD_REQUEST, 20000, "MEMBER_NICKNAME_EMPTY"),
-    MEMBER_PHONE_EMPTY(HttpStatus.BAD_REQUEST, 20001, "MEMBER_PHONE_EMPTY");
+    MEMBER_PHONE_EMPTY(HttpStatus.BAD_REQUEST, 20001, "MEMBER_PHONE_EMPTY"),
+    MEMBER_ORIGIN_REFRESH_TOKEN_EMPTY(HttpStatus.BAD_REQUEST, 20002, "MEMBER_ORIGIN_REFRESH_TOKEN_EMPTY");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/barowoori/foodpinbackend/member/command/domain/model/Member.java
+++ b/src/main/java/com/barowoori/foodpinbackend/member/command/domain/model/Member.java
@@ -49,17 +49,21 @@ public class Member {
     @Column(name = "image")
     private String image;
 
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
     protected Member() {
     }
 
     @Builder
-    public Member(String phone, String email, String image, String nickname, SocialLoginInfo socialLoginInfo) {
+    public Member(String phone, String email, String image, String nickname, SocialLoginInfo socialLoginInfo, String refreshToken) {
         setPhone(phone);
         this.email = email;
         setNickname(nickname);
         this.image = image;
         this.type = MemberType.NORMAL;
         this.socialLoginInfo = socialLoginInfo;
+        this.refreshToken = refreshToken;
     }
 
     public void updateProfile(ImageManager imageManager, String nickname, String originImageUrl, MultipartFile image) {
@@ -71,11 +75,15 @@ public class Member {
         setPhone(phone);
     }
 
-    private String makeNickname(GenerateNicknameService nicknameGenerator, String nickname) {
-        if (nickname == null || nickname.isEmpty()) {
-            return nicknameGenerator.generationNickname();
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public Boolean matchRefreshToken(String refreshToken) {
+        if (this.refreshToken == null) {
+            throw new CustomException(MemberErrorCode.MEMBER_ORIGIN_REFRESH_TOKEN_EMPTY);
         }
-        return nickname;
+        return this.refreshToken.equals(refreshToken);
     }
 
     private void setNickname(String nickname) {

--- a/src/main/java/com/barowoori/foodpinbackend/member/command/domain/repository/MemberRepository.java
+++ b/src/main/java/com/barowoori/foodpinbackend/member/command/domain/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.barowoori.foodpinbackend.member.command.domain.repository;
 import com.barowoori.foodpinbackend.member.command.domain.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MemberRepository extends JpaRepository<Member, String> {
+public interface MemberRepository extends JpaRepository<Member, String>, MemberRepositoryCustom {
     Member findByNickname(String nickname);
+    Member findByPhone(String phone);
 }

--- a/src/main/java/com/barowoori/foodpinbackend/member/command/domain/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/barowoori/foodpinbackend/member/command/domain/repository/MemberRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.barowoori.foodpinbackend.member.command.domain.repository;
+
+public interface MemberRepositoryCustom {
+}

--- a/src/main/java/com/barowoori/foodpinbackend/member/command/domain/repository/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/barowoori/foodpinbackend/member/command/domain/repository/MemberRepositoryCustomImpl.java
@@ -1,0 +1,16 @@
+package com.barowoori.foodpinbackend.member.command.domain.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import static com.barowoori.foodpinbackend.member.command.domain.model.QMember.member;
+
+@Repository
+public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public MemberRepositoryCustomImpl(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+}

--- a/src/test/java/com/barowoori/foodpinbackend/member/domain/MemberTests.java
+++ b/src/test/java/com/barowoori/foodpinbackend/member/domain/MemberTests.java
@@ -98,7 +98,7 @@ public class MemberTests {
         @Transactional
         @DisplayName("닉네임이 없으면 예외 처리")
         void WhenNicknameIsNull() {
-            CustomException exception = assertThrows(CustomException.class, ()->{
+            CustomException exception = assertThrows(CustomException.class, () -> {
                 Member.builder()
                         .email("email")
                         .phone("01012341234")
@@ -114,8 +114,9 @@ public class MemberTests {
     @DisplayName("회원 프로필 변경 테스트")
     class UpdateProfileSuccess {
         private Member member;
+
         @BeforeEach
-        void setUp()throws IOException {
+        void setUp() throws IOException {
             MockitoAnnotations.openMocks(this);
 
             String fileName = "test-file.jpg";
@@ -143,24 +144,24 @@ public class MemberTests {
         @Test
         @Transactional
         @DisplayName("닉네임은 전달된 값으로 변경된다")
-        void WhenChangedNickname(){
+        void WhenChangedNickname() {
             String originNickname = member.getNickname();
             assertEquals("nickname", originNickname);
 
-            member.updateProfile(imageManager, member.getNickname()+"1","originImageUrl", null);
+            member.updateProfile(imageManager, member.getNickname() + "1", "originImageUrl", null);
 
             String updatedNickname = member.getNickname();
-            assertEquals(originNickname+"1", updatedNickname);
+            assertEquals(originNickname + "1", updatedNickname);
         }
 
         @Test
         @Transactional
         @DisplayName("새 파일이 없고 기존 이미지 url을 전달할 경우 이미지는 변경되지 않는다")
-        void WhenNotExistNewFileAndExistOriginImageUrl(){
+        void WhenNotExistNewFileAndExistOriginImageUrl() {
             String originImage = member.getImage();
             assertEquals("originImageUrl", originImage);
 
-            member.updateProfile(imageManager, member.getNickname(),"originImageUrl", null);
+            member.updateProfile(imageManager, member.getNickname(), "originImageUrl", null);
 
             String updatedImage = member.getImage();
             assertEquals(originImage, updatedImage);
@@ -169,11 +170,11 @@ public class MemberTests {
         @Test
         @Transactional
         @DisplayName("새 파일이 있으면 이미지는 변경된다")
-        void WhenExistNewFileAndNotExistOriginImageUrl(){
+        void WhenExistNewFileAndNotExistOriginImageUrl() {
             String originImage = member.getImage();
             assertEquals("originImageUrl", originImage);
 
-            member.updateProfile(imageManager, member.getNickname(),null, multipartFile);
+            member.updateProfile(imageManager, member.getNickname(), null, multipartFile);
 
             String updatedImage = member.getImage();
             assertEquals("updatedImageUrl", updatedImage);
@@ -183,11 +184,11 @@ public class MemberTests {
         @Test
         @Transactional
         @DisplayName("새 파일이 있으면 기존 이미지 url을 보내도 이미지는 변경된다")
-        void WhenExistNewFileAndExistOriginImageUrl(){
+        void WhenExistNewFileAndExistOriginImageUrl() {
             String originImage = member.getImage();
             assertEquals("originImageUrl", originImage);
 
-            member.updateProfile(imageManager, member.getNickname(),"originImageUrl", multipartFile);
+            member.updateProfile(imageManager, member.getNickname(), "originImageUrl", multipartFile);
 
             String updatedImage = member.getImage();
             assertEquals("updatedImageUrl", updatedImage);
@@ -197,13 +198,105 @@ public class MemberTests {
         @Test
         @Transactional
         @DisplayName("새 파일과 기존 이미지 url이 없을 경우 이미지는 null로 저장된다")
-        void WhenNotExistNewFileAndNotExistOriginImageUrl(){
+        void WhenNotExistNewFileAndNotExistOriginImageUrl() {
             String originImage = member.getImage();
             assertEquals("originImageUrl", originImage);
 
-            member.updateProfile(imageManager, member.getNickname(),null, null);
+            member.updateProfile(imageManager, member.getNickname(), null, null);
 
             assertNull(member.getImage());
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 핸드폰 번호 변경 테스트")
+    class UpdatePhone {
+        private Member member;
+
+        @BeforeEach
+        void setUp() {
+            Member memberBuilder = Member.builder()
+                    .email("email")
+                    .phone("01012341234")
+                    .nickname("nickname")
+                    .socialLoginInfo(new SocialLoginInfo(SocialLoginType.KAKAO, "id123"))
+                    .image("originImageUrl")
+                    .build();
+            member = memberRepository.save(memberBuilder);
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("전달 받은 값으로 핸드폰 번호가 변경된다")
+        void WhenChangePhoneSuccess() {
+            String originPhone = member.getPhone();
+            assertEquals("01012341234", originPhone);
+
+            member.updatePhone(member.getPhone() + "1");
+
+            String updatedPhone = member.getPhone();
+            assertEquals(originPhone + "1", updatedPhone);
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("핸드폰 번호는 null이 될 수 없다")
+        void WhenChangePhoneFailed() {
+            CustomException exception = assertThrows(CustomException.class, () -> member.updatePhone(null));
+            assertEquals(MemberErrorCode.MEMBER_PHONE_EMPTY.getMessage(), exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("리프래시 토큰 관리 테스트")
+    class ManageRefreshToken {
+
+        private Member member;
+
+        @BeforeEach
+        void setUp() {
+            Member memberBuilder = Member.builder()
+                    .email("email")
+                    .phone("01012341234")
+                    .nickname("nickname")
+                    .socialLoginInfo(new SocialLoginInfo(SocialLoginType.KAKAO, "id123"))
+                    .image("originImageUrl")
+                    .refreshToken("originToken")
+                    .build();
+            member = memberRepository.save(memberBuilder);
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("업데이트할 때 리프레시 토큰은 전달받은 값으로 변경된다")
+        void WhenChangeRefreshTokenSuccess() {
+            member.updateRefreshToken("updatedToken");
+            assertEquals("updatedToken", member.getRefreshToken());
+        }
+
+
+        @Test
+        @Transactional
+        @DisplayName("리프레시 토큰이 일치하면 true를 반환한다")
+        void WhenMatchRefreshTokenSuccess() {
+            assertTrue(member.matchRefreshToken(member.getRefreshToken()));
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("리프레시 토큰이 일치하지 않으면 false를 반환한다")
+        void WhenNotMatchRefreshTokenSuccess() {
+            assertFalse(member.matchRefreshToken(member.getRefreshToken() + "1"));
+        }
+
+        @Test
+        @Transactional
+        @DisplayName("기존 리프레시 토큰이 null이면 예외 처리")
+        void WhenOriginRefreshTokenIsNull() {
+            member.updateRefreshToken(null);
+
+            CustomException exception = assertThrows(CustomException.class, () -> member.matchRefreshToken("new"));
+            assertEquals(MemberErrorCode.MEMBER_ORIGIN_REFRESH_TOKEN_EMPTY.getMessage(), exception.getMessage());
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11

## 📝작업 내용

> 닉네임으로 조회, 핸드폰번호로 조회 dao 구현
리프레시토큰 수정, 일치여부 확인 메서드 추가
querydsl 설정
### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
