### PR TITLE
:sparkles: 카테고리 및 트럭 관련 테이블 생성

### DIFF
--- a/src/main/java/com/barowoori/foodpinbackend/category/command/domain/model/Category.java
+++ b/src/main/java/com/barowoori/foodpinbackend/category/command/domain/model/Category.java
@@ -1,0 +1,22 @@
+package com.barowoori.foodpinbackend.category.command.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Table(name = "categories")
+@Getter
+public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    private String name;
+
+    protected Category(){
+    }
+
+    public Category(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/category/command/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/barowoori/foodpinbackend/category/command/domain/repository/CategoryRepository.java
@@ -1,0 +1,9 @@
+package com.barowoori.foodpinbackend.category.command.domain.repository;
+
+import com.barowoori.foodpinbackend.category.command.domain.model.Category;
+import com.barowoori.foodpinbackend.member.command.domain.repository.MemberRepositoryCustom;
+import com.barowoori.foodpinbackend.truck.command.domain.model.Truck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, String> {
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/exception/TruckErrorCode.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/exception/TruckErrorCode.java
@@ -1,0 +1,20 @@
+package com.barowoori.foodpinbackend.truck.command.domain.exception;
+
+import com.barowoori.foodpinbackend.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum TruckErrorCode implements ErrorCode {
+    MEMBER_NICKNAME_EMPTY(HttpStatus.BAD_REQUEST, 20000, "MEMBER_NICKNAME_EMPTY");
+
+    private final HttpStatus httpStatus;
+    private final Integer code;
+    private final String message;
+
+    TruckErrorCode(HttpStatus httpStatus, Integer code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/DocumentType.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/DocumentType.java
@@ -1,0 +1,17 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public enum DocumentType {
+    BUSINESS_REGISTRATION("사업자등록증"),
+    BUSINESS_LICENSE("영업신고증"),
+    VEHICLE_REGISTRATION("자동차등록증"),
+    SANITATION_EDUCATION("위생교육필증");
+
+    private String name;
+
+    DocumentType(String name){
+        this.name = name;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/Truck.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/Truck.java
@@ -1,0 +1,60 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "trucks")
+@Getter
+public class Truck {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "electricity_usage")
+    private Boolean electricityUsage;
+
+    @Column(name = "gas_usage")
+    private Boolean gasUsage;
+
+    @Column(name = "self_generation_availability")
+    private Boolean selfGenerationAvailability;
+
+    @Column(name = "is_deleted")
+    private Boolean isDeleted = false;
+
+    protected Truck(){}
+
+    public Truck(String name, LocalDateTime updatedAt, String updatedBy, String description, Boolean electricityUsage, Boolean gasUsage, Boolean selfGenerationAvailability, Boolean isDeleted) {
+        this.name = name;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+        this.description = description;
+        this.electricityUsage = electricityUsage;
+        this.gasUsage = gasUsage;
+        this.selfGenerationAvailability = selfGenerationAvailability;
+        this.isDeleted = isDeleted;
+    }
+
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckCategory.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckCategory.java
@@ -1,0 +1,37 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import com.barowoori.foodpinbackend.category.command.domain.model.Category;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "truck_categories")
+@Getter
+public class TruckCategory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @ManyToOne
+    @JoinColumn(name = "trucks_id")
+    private Truck truck;
+
+    @ManyToOne
+    @JoinColumn(name = "categories_id")
+    private Category category;
+
+    protected TruckCategory(){
+    }
+
+    public TruckCategory(Truck truck, Category category) {
+        this.truck = truck;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckDocument.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckDocument.java
@@ -1,0 +1,54 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "truck_documents")
+@Getter
+public class TruckDocument {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private DocumentType type;
+
+    @Column(name = "path", length = 500)
+    private String path;
+
+    @Column(name = "is_approval")
+    private Boolean approval;
+
+    @ManyToOne
+    @JoinColumn(name = "trucks_id")
+    private Truck truck;
+
+    protected TruckDocument() {
+    }
+
+    public TruckDocument(LocalDateTime updatedAt, String updatedBy, DocumentType type, String path, Boolean approval, Truck truck) {
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+        this.type = type;
+        this.path = path;
+        this.approval = approval;
+        this.truck = truck;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckManager.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckManager.java
@@ -1,0 +1,46 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import com.barowoori.foodpinbackend.member.command.domain.model.Member;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "truck_managers")
+@Getter
+public class TruckManager {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private TruckManagerRole role;
+
+    @Column(name = "role_updated_at")
+    private LocalDateTime roleUpdatedAt;
+
+    @ManyToOne
+    @JoinColumn(name = "members_id", nullable = false)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "trucks_id", nullable = false)
+    private Truck truck;
+
+    protected TruckManager() {
+    }
+
+    public TruckManager(TruckManagerRole role, LocalDateTime roleUpdatedAt, Member member, Truck truck) {
+        this.role = role;
+        this.roleUpdatedAt = roleUpdatedAt;
+        this.member = member;
+        this.truck = truck;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckManagerRole.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckManagerRole.java
@@ -1,0 +1,8 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import lombok.Getter;
+
+@Getter
+public enum TruckManagerRole {
+    OWNER, MEMBER;
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckMenu.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckMenu.java
@@ -1,0 +1,53 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "truck_menus")
+@Getter
+public class TruckMenu {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "price")
+    private Integer price;
+
+    @ManyToOne
+    @JoinColumn(name = "trucks_id", nullable = false)
+    private Truck truck;
+
+    protected TruckMenu() {
+    }
+
+    public TruckMenu(String name, LocalDateTime updatedAt, String updatedBy, String description, Integer price, Truck truck) {
+        this.name = name;
+        this.updatedAt = updatedAt;
+        this.updatedBy = updatedBy;
+        this.description = description;
+        this.price = price;
+        this.truck = truck;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckMenuPhoto.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckMenuPhoto.java
@@ -1,0 +1,39 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "truck_Menu_photos")
+@Getter
+public class TruckMenuPhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "path", length = 500)
+    private String path;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @ManyToOne
+    @JoinColumn(name = "truck_menus_id")
+    private TruckMenu truckMenu;
+
+    protected TruckMenuPhoto() {
+    }
+
+    public TruckMenuPhoto(String path, String updatedBy, TruckMenu truckMenu) {
+        this.path = path;
+        this.updatedBy = updatedBy;
+        this.truckMenu = truckMenu;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckPhoto.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckPhoto.java
@@ -1,0 +1,39 @@
+package com.barowoori.foodpinbackend.truck.command.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "truck_photos")
+@Getter
+public class TruckPhoto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "path", length = 500)
+    private String path;
+
+    @Column(name = "updated_by")
+    private String updatedBy;
+
+    @ManyToOne
+    @JoinColumn(name = "trucks_id")
+    private Truck truck;
+
+    protected TruckPhoto() {
+    }
+
+    public TruckPhoto(String path, String updatedBy, Truck truck) {
+        this.path = path;
+        this.updatedBy = updatedBy;
+        this.truck = truck;
+    }
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/TruckRepository.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/TruckRepository.java
@@ -1,0 +1,7 @@
+package com.barowoori.foodpinbackend.truck.command.domain.repository;
+
+import com.barowoori.foodpinbackend.truck.command.domain.model.Truck;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TruckRepository extends JpaRepository<Truck, String>, TruckRepositoryCustom {
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/TruckRepositoryCustom.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/TruckRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.barowoori.foodpinbackend.truck.command.domain.repository;
+
+public interface TruckRepositoryCustom {
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/TruckRepositoryCustomImpl.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/TruckRepositoryCustomImpl.java
@@ -1,0 +1,4 @@
+package com.barowoori.foodpinbackend.truck.command.domain.repository;
+
+public class TruckRepositoryCustomImpl implements TruckRepositoryCustom{
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #18 

## 📝작업 내용

> 카테고리는 트럭, 행사에서 공통으로 사용한다고 해서 따로 테이블로 뺐습니다.
> 트럭 관련된 엔티티를 생성했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
