### PR TITLE
⚡ 행사 상태 관리 스케쥴러 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventManagementService.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventManagementService.java
@@ -111,6 +111,7 @@ public class EventManagementService {
             }
 
             event.updateStatus(EventRecruitingStatus.RECRUITMENT_CANCELLED);
+            event.getRecruitDetail().closeSelection();
             NotificationEvent.raise(new EventRecruitmentCanceledNotificationEvent(event.getId(), event.getName()));
         } else throw new CustomException(EventErrorCode.WRONG_EVENT_RECRUITMENT_STATUS);
 

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventService.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventService.java
@@ -279,6 +279,7 @@ public class EventService {
 
         if (eventRecruitDetail != null && eventRecruitDetail.getRecruitingStatus().equals(EventRecruitingStatus.RECRUITING)) {
             eventRecruitDetail.updateStatus(EventRecruitingStatus.RECRUITMENT_CANCELLED);
+            eventRecruitDetail.closeSelection();
             NotificationEvent.raise(new EventRecruitmentCanceledNotificationEvent(event.getId(), event.getName()));
         }
 

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventStatusUpdater.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventStatusUpdater.java
@@ -27,40 +27,37 @@ public class EventStatusUpdater {
     @Scheduled(cron = "0 * * * * *")
     @Transactional
     public void updateEventStatuses() {
+        List<Event> selectingEvents = eventRepository.findByRecruitDetail_IsSelectingTrueAndIsDeletedFalse();
         LocalDateTime now = LocalDateTime.now();
-        List<Event> recruitingEvents = eventRepository
-                .findByRecruitDetail_RecruitingStatusAndIsDeletedFalse(EventRecruitingStatus.RECRUITING);
 
-        for (Event event : recruitingEvents) {
+        for (Event event : selectingEvents) {
             EventRecruitDetail detail = event.getRecruitDetail();
             LocalDateTime recruitEndDateTime = detail.getRecruitEndDateTime();
+            boolean isRecruitEndReached = recruitEndDateTime != null && !recruitEndDateTime.isAfter(now);
+
+            if (isRecruitEndReached && detail.getRecruitingStatus().equals(EventRecruitingStatus.RECRUITING)) {
+                closeRecruiting(event);
+            }
+
             LocalDateTime eventEndDateTime = event.getEventDates().stream()
                     .map(eventDate -> LocalDateTime.of(eventDate.getDate(), eventDate.getEndTime()))
                     .max(LocalDateTime::compareTo)
                     .orElse(null);
+            boolean isEventEnded = eventEndDateTime != null && eventEndDateTime.toLocalDate().atTime(23, 59, 59).isBefore(now);
 
-            boolean isEventEnded = eventEndDateTime != null && !eventEndDateTime.toLocalDate().atTime(23, 59, 59).isAfter(now);
-            boolean isRecruitEndReached = recruitEndDateTime != null && !recruitEndDateTime.isAfter(now);
-
-            if (isEventEnded && Boolean.TRUE.equals(detail.getIsSelecting())) {
-                closeRecruitingAndSelection(event);
-            } else if (isRecruitEndReached) {
-                closeRecruitingByDeadline(event);
+            if (isEventEnded) {
+                closeSelection(event);
             }
         }
     }
 
-    private void closeRecruitingAndSelection(Event event) {
-        EventRecruitDetail detail = event.getRecruitDetail();
-        detail.closeSelection();
-        detail.updateStatus(EventRecruitingStatus.RECRUITMENT_CLOSED);
+    private void closeRecruiting(Event event) {
+        event.updateStatus(EventRecruitingStatus.RECRUITMENT_CLOSED);
 
-        List<EventApplication> pendingApplications =
-                eventApplicationRepository.findAllByEventAndStatus(event, EventApplicationStatus.PENDING);
+        List<EventApplication> pendingApplications = eventApplicationRepository.findAllByEventAndStatus(event, EventApplicationStatus.PENDING);
 
         for (EventApplication application : pendingApplications) {
             application.reject();
-            eventApplicationRepository.save(application);
 
             NotificationEvent.raise(new SelectionNotSelectedNotificationEvent(
                     event.getId(),
@@ -68,36 +65,22 @@ public class EventStatusUpdater {
                     application.getId()
             ));
         }
+    }
 
-        List<EventTruck> eventTrucks = eventTruckRepository.findAllByEventAndStatus(event, EventTruckStatus.PENDING);
-        EventRecruitDetail eventRecruitDetail = event.getRecruitDetail();
+    private void closeSelection(Event event) {
+        EventRecruitDetail detail = event.getRecruitDetail();
+        detail.closeSelection();
 
-        for (EventTruck eventTruck : eventTrucks) {
-            eventRecruitDetail.decreaseSelectedCount();
+        List<EventTruck> pendingEventTrucks = eventTruckRepository.findAllByEventAndStatus(event, EventTruckStatus.PENDING);
+
+        for (EventTruck eventTruck : pendingEventTrucks) {
+            detail.decreaseSelectedCount();
             eventTruck.reject();
 
             NotificationEvent.raise(new SelectionCanceledNotificationEvent(
                     event.getId(),
                     event.getName(),
                     eventTruck.getTruck().getName()
-            ));
-        }
-    }
-
-    private void closeRecruitingByDeadline(Event event) {
-        event.updateStatus(EventRecruitingStatus.RECRUITMENT_CLOSED);
-
-        List<EventApplication> pendingApplications =
-                eventApplicationRepository.findAllByEventAndStatus(event, EventApplicationStatus.PENDING);
-
-        for (EventApplication application : pendingApplications) {
-            application.reject();
-            eventApplicationRepository.save(application);
-
-            NotificationEvent.raise(new SelectionNotSelectedNotificationEvent(
-                    event.getId(),
-                    event.getName(),
-                    application.getId()
             ));
         }
     }

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/EventRepository.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/EventRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface EventRepository extends JpaRepository<Event, String>, EventRepositoryCustom {
     List<Event> findByRecruitDetail_RecruitingStatusIn(List<EventRecruitingStatus> statuses);
-    List<Event> findByRecruitDetail_RecruitingStatusAndIsDeletedFalse(EventRecruitingStatus recruitingStatus);
+    List<Event> findByRecruitDetail_IsSelectingTrueAndIsDeletedFalse();
     List<Event> findByRecruitDetail_RecruitingStatusAndRecruitDetail_RecruitEndDateTimeLessThanEqualAndIsDeletedFalse(EventRecruitingStatus recruitingStatus, LocalDateTime time);
     List<Event> findAllByCreatedBy(String createdBy);
 }

--- a/src/test/java/com/barowoori/foodpinbackend/event/application/service/EventStatusUpdaterTests.java
+++ b/src/test/java/com/barowoori/foodpinbackend/event/application/service/EventStatusUpdaterTests.java
@@ -45,6 +45,7 @@ public class EventStatusUpdaterTests {
     void testCloseRecruitingEventsByDeadline() {
         // given
         Event event = saveBasicEvent();
+
         EventDate eventDate = eventDateRepository.save(EventDate.builder()
                 .event(event)
                 .date(LocalDate.now().plusDays(1))
@@ -55,10 +56,10 @@ public class EventStatusUpdaterTests {
 
         EventRecruitDetail detail = EventRecruitDetail.builder()
                 .event(event)
-                .recruitEndDateTime(LocalDateTime.now().minusDays(1))
+                .recruitEndDateTime(LocalDateTime.now().minusMinutes(1))
                 .recruitingStatus(EventRecruitingStatus.RECRUITING)
                 .recruitCount(5)
-                .applicantCount(0)
+                .applicantCount(1)
                 .selectedCount(0)
                 .isSelecting(true)
                 .entryFee(0)
@@ -68,11 +69,13 @@ public class EventStatusUpdaterTests {
         recruitDetailRepository.save(detail);
         event.initEventRecruitDetail(detail);
 
-        EventApplication application = eventApplicationRepository.save(EventApplication.builder()
-                .event(event)
-                .status(EventApplicationStatus.PENDING)
-                .isRead(false)
-                .build());
+        EventApplication application = eventApplicationRepository.save(
+                EventApplication.builder()
+                        .event(event)
+                        .status(EventApplicationStatus.PENDING)
+                        .isRead(false)
+                        .build()
+        );
 
         // when
         eventStatusUpdater.updateEventStatuses();
@@ -80,29 +83,18 @@ public class EventStatusUpdaterTests {
         // then
         Event updated = eventRepository.findById(event.getId()).orElseThrow();
         EventApplication updatedApplication = eventApplicationRepository.findById(application.getId()).orElseThrow();
+
         assertThat(updated.getRecruitDetail().getRecruitingStatus()).isEqualTo(EventRecruitingStatus.RECRUITMENT_CLOSED);
         assertThat(updatedApplication.getStatus()).isEqualTo(EventApplicationStatus.REJECTED);
     }
+
 
     @Test
     @Transactional
     void testCloseSelectingEventsByEndDate() {
         // given
-        Member member = memberRepository.save(Member.builder()
-                .email("email")
-                .phone("01012341234")
-                .nickname("nickname")
-                .socialLoginInfo(new SocialLoginInfo(SocialLoginType.KAKAO, "id123"))
-                .build());
-        Event event = eventRepository.save(Event.builder()
-                .name("스케쥴러 테스트 이벤트")
-                .createdBy(member.getId())
-                .description("desc")
-                .guidelines("guideline")
-                .isDeleted(false)
-                .submissionEmail("test@example.com")
-                .documentSubmissionTarget(EventDocumentSubmissionTarget.ALL_APPLICANTS)
-                .build());
+        Event event = saveBasicEvent();
+
         EventDate ed = eventDateRepository.save(EventDate.builder()
                 .event(event)
                 .date(LocalDate.now().minusDays(1))
@@ -114,10 +106,10 @@ public class EventStatusUpdaterTests {
         EventRecruitDetail detail = EventRecruitDetail.builder()
                 .event(event)
                 .recruitEndDateTime(LocalDateTime.now().minusDays(2))
-                .recruitingStatus(EventRecruitingStatus.RECRUITING)
+                .recruitingStatus(EventRecruitingStatus.RECRUITMENT_CLOSED)
                 .recruitCount(5)
-                .applicantCount(0)
-                .selectedCount(0)
+                .applicantCount(1)
+                .selectedCount(1)
                 .isSelecting(true)
                 .entryFee(0)
                 .generatorRequirement(false)
@@ -125,12 +117,6 @@ public class EventStatusUpdaterTests {
                 .build();
         recruitDetailRepository.save(detail);
         event.initEventRecruitDetail(detail);
-
-        EventApplication app = eventApplicationRepository.save(EventApplication.builder()
-                .event(event)
-                .status(EventApplicationStatus.PENDING)
-                .isRead(false)
-                .build());
 
         Truck truck = truckRepository.save(Truck.builder()
                 .name("테스트 푸드트럭")
@@ -142,10 +128,13 @@ public class EventStatusUpdaterTests {
                 .truck(truck)
                 .status(EventTruckStatus.PENDING)
                 .build());
-        EventTruckDate eventTruckDate = eventTruckDateRepository.save(EventTruckDate.builder()
-                .eventDate(ed)
-                .eventTruck(eventTruck)
-                .build());
+
+        EventTruckDate eventTruckDate = eventTruckDateRepository.save(
+                EventTruckDate.builder()
+                        .eventDate(ed)
+                        .eventTruck(eventTruck)
+                        .build()
+        );
         eventTruck.getDates().add(eventTruckDate);
 
         // when
@@ -153,13 +142,12 @@ public class EventStatusUpdaterTests {
 
         // then
         Event updatedEvent = eventRepository.findById(event.getId()).orElseThrow();
-        EventApplication updatedApp = eventApplicationRepository.findById(app.getId()).orElseThrow();
         EventTruck updatedEventTruck = eventTruckRepository.findById(eventTruck.getId()).orElseThrow();
 
         assertThat(updatedEvent.getRecruitDetail().getIsSelecting()).isFalse();
-        assertThat(updatedApp.getStatus()).isEqualTo(EventApplicationStatus.REJECTED);
         assertThat(updatedEventTruck.getStatus()).isEqualTo(EventTruckStatus.REJECTED);
     }
+
 
     private Event saveBasicEvent() {
         Member memberBuilder = Member.builder()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #151 

## 📝작업 내용

> 행사 상태 관리 스케쥴러 및 테스트 코드 수정
> 행사 모집 취소 시 선정 종료
> 행사 삭제 시 선정 종료