### PR TITLE
:sparkles: 행사 목록 조회 api 수정, 트럭 목록 조회 및 상세 조회 api에 사업자등록증 인증 여부 추가

### DIFF
--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventAppliedTruckDetail.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventAppliedTruckDetail.java
@@ -1,16 +1,14 @@
 package com.barowoori.foodpinbackend.event.command.domain.repository.dto;
 
 import com.barowoori.foodpinbackend.category.command.domain.model.Category;
+import com.barowoori.foodpinbackend.document.command.domain.model.DocumentType;
 import com.barowoori.foodpinbackend.event.command.domain.model.EventApplication;
 import com.barowoori.foodpinbackend.event.command.domain.model.EventApplicationDate;
 import com.barowoori.foodpinbackend.event.command.domain.model.EventApplicationStatus;
 import com.barowoori.foodpinbackend.event.command.domain.model.EventDate;
 import com.barowoori.foodpinbackend.file.command.domain.service.ImageManager;
 import com.barowoori.foodpinbackend.region.command.domain.repository.dto.RegionCode;
-import com.barowoori.foodpinbackend.truck.command.domain.model.Truck;
-import com.barowoori.foodpinbackend.truck.command.domain.model.TruckManager;
-import com.barowoori.foodpinbackend.truck.command.domain.model.TruckManagerRole;
-import com.barowoori.foodpinbackend.truck.command.domain.model.TruckMenu;
+import com.barowoori.foodpinbackend.truck.command.domain.model.*;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDetail;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDocumentManager;
 import lombok.Builder;
@@ -35,6 +33,11 @@ public class EventAppliedTruckDetail extends TruckDetail {
                 .truck(TruckInfo.of(truck, imageManager))
                 .documents(truckDocumentManager.getTypes())
                 .documentInfos(truckDocumentManager.getDocuments().stream().map(TruckDocumentInfo::of).toList())
+                .businessRegistrationApproved(
+                        truckDocumentManager.getDocuments() != null? truckDocumentManager.getDocuments().stream()
+                                .filter(document -> document.getType().equals(DocumentType.BUSINESS_REGISTRATION))
+                                .map(TruckDocument::getStatus)
+                                .anyMatch(status -> status.equals(TruckDocumentStatus.APPROVED)) : Boolean.FALSE)
                 .regions(regions)
                 .categories(categories.stream()
                         .sorted(Comparator.comparing(Category::getCode))

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventSelectedTruckDetail.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventSelectedTruckDetail.java
@@ -1,13 +1,11 @@
 package com.barowoori.foodpinbackend.event.command.domain.repository.dto;
 
 import com.barowoori.foodpinbackend.category.command.domain.model.Category;
+import com.barowoori.foodpinbackend.document.command.domain.model.DocumentType;
 import com.barowoori.foodpinbackend.event.command.domain.model.*;
 import com.barowoori.foodpinbackend.file.command.domain.service.ImageManager;
 import com.barowoori.foodpinbackend.region.command.domain.repository.dto.RegionCode;
-import com.barowoori.foodpinbackend.truck.command.domain.model.Truck;
-import com.barowoori.foodpinbackend.truck.command.domain.model.TruckManager;
-import com.barowoori.foodpinbackend.truck.command.domain.model.TruckManagerRole;
-import com.barowoori.foodpinbackend.truck.command.domain.model.TruckMenu;
+import com.barowoori.foodpinbackend.truck.command.domain.model.*;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDetail;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDocumentManager;
 import lombok.Getter;
@@ -28,6 +26,11 @@ public class EventSelectedTruckDetail extends TruckDetail {
                 .truck(TruckInfo.of(truck, imageManager))
                 .documents(truckDocumentManager.getTypes())
                 .documentInfos(truckDocumentManager.getDocuments().stream().map(TruckDocumentInfo::of).toList())
+                .businessRegistrationApproved(
+                        truckDocumentManager.getDocuments() != null? truckDocumentManager.getDocuments().stream()
+                                .filter(document -> document.getType().equals(DocumentType.BUSINESS_REGISTRATION))
+                                .map(TruckDocument::getStatus)
+                                .anyMatch(status -> status.equals(TruckDocumentStatus.APPROVED)) : Boolean.FALSE)
                 .regions(regions)
                 .categories(categories.stream()
                         .sorted(Comparator.comparing(Category::getCode))

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/querydsl/EventRepositoryCustom.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/querydsl/EventRepositoryCustom.java
@@ -20,13 +20,13 @@ public interface EventRepositoryCustom {
     Page<Event> findEventListByFilter(String searchTerm, Map<RegionType, List<String>> regionIds,
                                       LocalDate startDate, LocalDate endDate,
                                       List<String> categoryCodes,
-                                      EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes,
+                                      EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Boolean isCatering,
                                       Pageable pageable);
     Event findEventDetail(String eventId);
     Page<Event> findLikeEventListByFilter(String memberId, String searchTerm, Map<RegionType, List<String>> regionIds,
                                           LocalDate startDate, LocalDate endDate,
                                           List<String> categoryCodes,
-                                          EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Pageable pageable);
+                                          EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Boolean isCatering, Pageable pageable);
 
     List<Event> findEndedEventsByIsSelecting(LocalDateTime now, Boolean isSelecting);
 

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/querydsl/EventRepositoryCustomImpl.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/querydsl/EventRepositoryCustomImpl.java
@@ -38,6 +38,7 @@ import static com.barowoori.foodpinbackend.event.command.domain.model.QEventView
 import static com.barowoori.foodpinbackend.file.command.domain.model.QFile.file;
 import static com.barowoori.foodpinbackend.member.command.domain.model.QEventLike.eventLike;
 import static com.barowoori.foodpinbackend.member.command.domain.model.QMember.member;
+import static com.barowoori.foodpinbackend.truck.command.domain.model.QTruck.truck;
 
 public class EventRepositoryCustomImpl implements EventRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
@@ -65,7 +66,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
     public Page<Event> findEventListByFilter(String searchTerm, Map<RegionType, List<String>> regionIds,
                                              LocalDate startDate, LocalDate endDate,
                                              List<String> categoryCodes,
-                                             EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes,
+                                             EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Boolean isCatering,
                                              Pageable pageable) {
         List<Event> events = jpaQueryFactory.selectDistinct(event)
                 .from(event)
@@ -81,7 +82,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                         event.isDeleted.isFalse()
                                 .and(eventRecruitDetail.recruitingStatus.eq(EventRecruitingStatus.RECRUITING))
                                 .and(
-                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, event, eventDate, category)
+                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, isCatering, event, eventDate, category)
                                                 .and(regionFilterCondition(regionIds))
                                 )
                 )
@@ -100,7 +101,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                         event.isDeleted.isFalse()
                                 .and(eventRecruitDetail.recruitingStatus.eq(EventRecruitingStatus.RECRUITING))
                                 .and(
-                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, event, eventDate, category)
+                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, isCatering, event, eventDate, category)
                                                 .and(regionFilterCondition(regionIds))
                                 )
                 )
@@ -113,7 +114,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
     public Page<Event> findLikeEventListByFilter(String memberId, String searchTerm, Map<RegionType, List<String>> regionIds,
                                                  LocalDate startDate, LocalDate endDate,
                                                  List<String> categoryCodes,
-                                                 EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes,
+                                                 EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Boolean isCatering,
                                                  Pageable pageable) {
         List<Event> events = jpaQueryFactory.selectDistinct(event)
                 .from(event)
@@ -129,7 +130,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                 .where(
                         event.isDeleted.isFalse()
                                 .and(
-                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, event, eventDate, category)
+                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, isCatering, event, eventDate, category)
                                                 .and(regionFilterCondition(regionIds))
                                 )
                 )
@@ -148,7 +149,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                 .where(
                         event.isDeleted.isFalse()
                                 .and(
-                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, event, eventDate, category)
+                                        createFilterBuilder(searchTerm, categoryCodes, startDate, endDate, type, expectedParticipants, truckTypes, isCatering, event, eventDate, category)
                                                 .and(regionFilterCondition(regionIds))
                                 )
                 )
@@ -176,7 +177,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
     }
 
     public BooleanBuilder createFilterBuilder(String searchTerm, List<String> categoryCodes, LocalDate startDate, LocalDate endDate,
-                                              EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes,
+                                              EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Boolean isCatering,
                                               QEvent event, QEventDate eventDate, QCategory category) {
         BooleanBuilder filterBuilder = new BooleanBuilder();
         addSearchTermFilter(event, searchTerm, filterBuilder);
@@ -185,6 +186,7 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
         addTruckTypeFilter(truckTypes, filterBuilder);
         addEventTypeFilter(type, filterBuilder);
         addExpectedParticipantsFilter(expectedParticipants, filterBuilder);
+        addCateringFilter(isCatering, filterBuilder);
         return filterBuilder;
     }
 
@@ -253,6 +255,17 @@ public class EventRepositoryCustomImpl implements EventRepositoryCustom {
                 .or(eventRegion.regionId.in(regionIds.get(RegionType.REGION_SI)).and(eventRegion.regionType.eq(RegionType.REGION_SI)))
                 .or(eventRegion.regionId.in(regionIds.get(RegionType.REGION_GU)).and(eventRegion.regionType.eq(RegionType.REGION_GU)))
                 .or(eventRegion.regionId.in(regionIds.get(RegionType.REGION_GUN)).and(eventRegion.regionType.eq(RegionType.REGION_GUN)));
+    }
+
+    private void addCateringFilter(Boolean isCatering, BooleanBuilder builder) {
+        if (isCatering == null) {
+            return;
+        }
+
+        if (!isCatering) {//일반판매일 경우
+            return;
+        }
+        builder.and(event.saleType.eq(SaleType.CATERING));
     }
 
     private List<OrderSpecifier> getOrderSpecifier(Sort sort) {

--- a/src/main/java/com/barowoori/foodpinbackend/event/controller/EventController.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/controller/EventController.java
@@ -108,9 +108,10 @@ public class EventController {
                                                                         @RequestParam(value = "type", required = false) EventType type,
                                                                         @RequestParam(value = "expectedParticipants", required = false) ExpectedParticipants expectedParticipants,
                                                                         @RequestParam(value = "truckTypes", required = false) Set<TruckType> truckTypes,
+                                                                        @RequestParam(value = "isCatering", required = false) Boolean isCatering,
                                                                         @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        Page<EventList> eventLists = eventListService.findEventList(searchTerm, regionCodes, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, pageable);
+        Page<EventList> eventLists = eventListService.findEventList(searchTerm, regionCodes, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, isCatering, pageable);
         CommonResponse<Page<EventList>> commonResponse = CommonResponse.<Page<EventList>>builder()
                 .data(eventLists)
                 .build();
@@ -132,10 +133,11 @@ public class EventController {
                                                                             @RequestParam(value = "type", required = false) EventType type,
                                                                             @RequestParam(value = "expectedParticipants", required = false) ExpectedParticipants expectedParticipants,
                                                                             @RequestParam(value = "truckTypes", required = false) Set<TruckType> truckTypes,
+                                                                            @RequestParam(value = "isCatering", required = false) Boolean isCatering,
                                                                             @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
-        Page<EventList> eventLists = eventListService.findLikeEventList(memberId, searchTerm, regionCodes, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, pageable);
+        Page<EventList> eventLists = eventListService.findLikeEventList(memberId, searchTerm, regionCodes, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, isCatering, pageable);
         CommonResponse<Page<EventList>> commonResponse = CommonResponse.<Page<EventList>>builder()
                 .data(eventLists)
                 .build();

--- a/src/main/java/com/barowoori/foodpinbackend/event/query/application/EventListService.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/query/application/EventListService.java
@@ -41,10 +41,10 @@ public class EventListService {
     public Page<EventList> findEventList(String searchTerm, List<String> regionCodes,
                                          LocalDate startDate, LocalDate endDate,
                                          List<String> categoryCodes,
-                                         EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes,
+                                         EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Boolean isCatering,
                                          Pageable pageable) {
         Map<RegionType, List<String>> regionIds = regionDoRepository.findRegionIdsByFilter(regionCodes);
-        Page<Event> events = eventRepository.findEventListByFilter(searchTerm, regionIds, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, pageable);
+        Page<Event> events = eventRepository.findEventListByFilter(searchTerm, regionIds, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, isCatering, pageable);
         List<String> eventIds = events.map(Event::getId).stream().toList();
         Map<String, List<String>> regionNames = eventRegionFullNameGenerator.findRegionNamesByEventIds(eventIds);
 
@@ -55,10 +55,10 @@ public class EventListService {
     public Page<EventList> findLikeEventList(String memberId, String searchTerm, List<String> regionCodes,
                                              LocalDate startDate, LocalDate endDate,
                                              List<String> categoryCodes,
-                                             EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes,
+                                             EventType type, ExpectedParticipants expectedParticipants, Set<TruckType> truckTypes, Boolean isCatering,
                                              Pageable pageable) {
         Map<RegionType, List<String>> regionIds = regionDoRepository.findRegionIdsByFilter(regionCodes);
-        Page<Event> events = eventRepository.findLikeEventListByFilter(memberId, searchTerm, regionIds, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, pageable);
+        Page<Event> events = eventRepository.findLikeEventListByFilter(memberId, searchTerm, regionIds, startDate, endDate, categoryCodes, type, expectedParticipants, truckTypes, isCatering, pageable);
         List<String> eventIds = events.map(Event::getId).stream().toList();
         Map<String, List<String>> regionNames = eventRegionFullNameGenerator.findRegionNamesByEventIds(eventIds);
 

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/dto/TruckDetail.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/dto/TruckDetail.java
@@ -24,20 +24,27 @@ public class TruckDetail {
     private TruckInfo truck;
     private List<DocumentType> documents;
     private List<TruckDocumentInfo> documentInfos;
+    private Boolean businessRegistrationApproved;
     private List<RegionCode> regions;
     private List<CategoryInfo> categories;
     private List<MenuInfo> menus;
     private Boolean isLike;
     private String regionList;
 
-    public static TruckDetail of(TruckManager truckManager, Truck truck, TruckDocumentManager truckDocumentManager, List<RegionCode> regions, String regionList, List<Category> categories,List<TruckMenu> truckMenus, Boolean isLike, ImageManager imageManager) {
+    public static TruckDetail of(TruckManager truckManager, Truck truck, TruckDocumentManager truckDocumentManager, List<RegionCode> regions, String regionList, List<Category> categories, List<TruckMenu> truckMenus, Boolean isLike, ImageManager imageManager) {
         return TruckDetail.builder()
                 .isTruckManager(truckManager != null)
                 .isAvailableUpdate(checkAvailableUpdate(truckManager))
                 .isAvailableDelete(checkAvailableDelete(truckManager))
                 .truck(TruckInfo.of(truck, imageManager))
                 .documents(truckDocumentManager.getTypes())
+
                 .documentInfos(truckDocumentManager.getDocuments().stream().map(TruckDocumentInfo::of).toList())
+                .businessRegistrationApproved(
+                        truckDocumentManager.getDocuments() != null? truckDocumentManager.getDocuments().stream()
+                                .filter(document -> document.getType().equals(DocumentType.BUSINESS_REGISTRATION))
+                                .map(TruckDocument::getStatus)
+                                .anyMatch(status -> status.equals(TruckDocumentStatus.APPROVED)) : Boolean.FALSE)
                 .regions(regions)
                 .categories(categories.stream()
                         .sorted(Comparator.comparing(Category::getCode))
@@ -145,6 +152,7 @@ public class TruckDetail {
     public static class Photo {
         private String id;
         private String path;
+
         public static Photo of(File file, ImageManager imageManager) {
             return Photo.builder()
                     .id(file.getId())
@@ -155,12 +163,12 @@ public class TruckDetail {
 
     @Getter
     @Builder
-    public static class TruckDocumentInfo{
+    public static class TruckDocumentInfo {
         private DocumentType type;
         private LocalDate date;
         private TruckDocumentStatus status;
 
-        public static TruckDocumentInfo of(TruckDocument truckDocument){
+        public static TruckDocumentInfo of(TruckDocument truckDocument) {
             return TruckDocumentInfo.builder()
                     .type(truckDocument.getType())
                     .date(truckDocument.getUpdatedAt().toLocalDate())

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/dto/TruckDocumentInfoDto.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/dto/TruckDocumentInfoDto.java
@@ -1,0 +1,13 @@
+package com.barowoori.foodpinbackend.truck.command.domain.repository.dto;
+
+import com.barowoori.foodpinbackend.document.command.domain.model.DocumentType;
+import com.barowoori.foodpinbackend.truck.command.domain.model.TruckDocumentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TruckDocumentInfoDto {
+    private DocumentType type;
+    private TruckDocumentStatus status;
+}

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/dto/TruckList.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/dto/TruckList.java
@@ -3,11 +3,13 @@ package com.barowoori.foodpinbackend.truck.command.domain.repository.dto;
 import com.barowoori.foodpinbackend.document.command.domain.model.DocumentType;
 import com.barowoori.foodpinbackend.file.command.domain.service.ImageManager;
 import com.barowoori.foodpinbackend.truck.command.domain.model.Truck;
+import com.barowoori.foodpinbackend.truck.command.domain.model.TruckDocumentStatus;
 import com.barowoori.foodpinbackend.truck.command.domain.model.TruckMenu;
 import com.barowoori.foodpinbackend.truck.command.domain.model.TruckPhoto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -16,6 +18,7 @@ public class TruckList {
     private String id;
     private String name;
     private List<DocumentType> documents;
+    private Boolean businessRegistrationApproved;
     private List<String> regions;
     private String regionList;
     private List<String> menuNames;
@@ -23,12 +26,16 @@ public class TruckList {
     private Integer avgMenuPrice;
     private List<String> menuPhotos;
 
-    public static TruckList of(Truck truck, List<DocumentType> documents, List<String> regions, String regionList, ImageManager imageManager) {
-
+    public static TruckList of(Truck truck, List<TruckDocumentInfoDto> documents, List<String> regions, String regionList, ImageManager imageManager) {
         return TruckList.builder()
                 .id(truck.getId())
                 .name(truck.getName())
-                .documents(documents)
+                .businessRegistrationApproved(documents != null ?
+                        documents.stream()
+                                .filter(document -> document.getType().equals(DocumentType.BUSINESS_REGISTRATION))
+                                .map(TruckDocumentInfoDto::getStatus)
+                                .anyMatch(status -> status.equals(TruckDocumentStatus.APPROVED)) : Boolean.FALSE)
+                .documents(documents != null ? documents.stream().map(TruckDocumentInfoDto::getType).toList() : new ArrayList<>())
                 .regions(regions)
                 .regionList(regionList)
                 .menuNames(truck.getSortedTruckMenuNames())

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/querydsl/TruckDocumentRepositoryCustom.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/querydsl/TruckDocumentRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.barowoori.foodpinbackend.truck.command.domain.repository.querydsl;
 import com.barowoori.foodpinbackend.document.command.domain.model.BusinessRegistration;
 import com.barowoori.foodpinbackend.document.command.domain.model.DocumentType;
 import com.barowoori.foodpinbackend.truck.command.domain.model.TruckDocument;
+import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDocumentInfoDto;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDocumentManager;
 
 import java.util.List;
@@ -11,6 +12,6 @@ import java.util.Map;
 public interface TruckDocumentRepositoryCustom {
     TruckDocumentManager getDocumentManager(String truckId);
     BusinessRegistration getBusinessRegistrationDocumentByTruckId(String truckId);
-    Map<String, List<DocumentType>> getDocumentTypeByTruckIds(List<String> truckIds);
+    Map<String, List<TruckDocumentInfoDto>> getDocumentTypeByTruckIds(List<String> truckIds);
     List<TruckDocument> getTruckDocumentFiles(String truckId);
 }

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/querydsl/TruckDocumentRepositoryCustomImpl.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/repository/querydsl/TruckDocumentRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import com.barowoori.foodpinbackend.file.command.domain.model.QFile;
 import com.barowoori.foodpinbackend.truck.command.domain.model.QTruck;
 import com.barowoori.foodpinbackend.truck.command.domain.model.QTruckDocument;
 import com.barowoori.foodpinbackend.truck.command.domain.model.TruckDocument;
+import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDocumentInfoDto;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDocumentManager;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -46,18 +47,28 @@ public class TruckDocumentRepositoryCustomImpl implements TruckDocumentRepositor
     }
 
     @Override
-    public Map<String, List<DocumentType>> getDocumentTypeByTruckIds(List<String> truckIds) {
+    public Map<String, List<TruckDocumentInfoDto>> getDocumentTypeByTruckIds(List<String> truckIds) {
+
         QTruckDocument truckDocument = QTruckDocument.truckDocument;
         QTruck truck = QTruck.truck;
-        List<Tuple> results = jpaQueryFactory.select(truck.id, truckDocument.type)
+
+        List<Tuple> results = jpaQueryFactory
+                .select(truck.id, truckDocument.type, truckDocument.status)
                 .from(truckDocument)
-                .join(truckDocument.truck, truck).on(truckDocument.truck.id.in(truckIds))
+                .join(truckDocument.truck, truck)
+                .where(truck.id.in(truckIds))
                 .fetch();
 
         return results.stream()
                 .collect(Collectors.groupingBy(
                         tuple -> tuple.get(truck.id),
-                        Collectors.mapping(tuple -> tuple.get(truckDocument.type), Collectors.toList())
+                        Collectors.mapping(
+                                tuple -> new TruckDocumentInfoDto(
+                                        tuple.get(truckDocument.type),
+                                        tuple.get(truckDocument.status)
+                                ),
+                                Collectors.toList()
+                        )
                 ));
     }
 

--- a/src/main/java/com/barowoori/foodpinbackend/truck/query/application/TruckListService.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/query/application/TruckListService.java
@@ -13,6 +13,7 @@ import com.barowoori.foodpinbackend.truck.command.domain.repository.TruckDocumen
 import com.barowoori.foodpinbackend.truck.command.domain.repository.TruckMenuRepository;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.TruckRegionRepository;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.TruckRepository;
+import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckDocumentInfoDto;
 import com.barowoori.foodpinbackend.truck.command.domain.repository.dto.TruckList;
 import org.junit.Before;
 import org.springframework.data.domain.Page;
@@ -80,7 +81,7 @@ public class TruckListService {
         Page<Truck> trucks = truckRepository.findTruckListByFilter(searchTerm, categoryNames, regionIds, types, minAvgMenuPrice, maxAvgMenuPrice,
                 colors, bodyTypes, paymentMethods, proofIssuanceTypes, isCatering, pageable);
         List<String> truckIds = trucks.map(Truck::getId).stream().toList();
-        Map<String, List<DocumentType>> documents = truckDocumentRepository.getDocumentTypeByTruckIds(truckIds);
+        Map<String, List<TruckDocumentInfoDto>> documents = truckDocumentRepository.getDocumentTypeByTruckIds(truckIds);
 
         return trucks.map(truck -> {
             List<String> regionNames = truck.getTruckRegionNames(regionSearchProcessor);
@@ -108,7 +109,7 @@ public class TruckListService {
         Page<Truck> trucks = truckRepository.findLikeTruckListByFilter(memberId, searchTerm, categoryNames, regionIds, types, minAvgMenuPrice, maxAvgMenuPrice,
                 colors, bodyTypes, paymentMethods, proofIssuanceTypes, isCatering, pageable);
         List<String> truckIds = trucks.map(Truck::getId).stream().toList();
-        Map<String, List<DocumentType>> documents = truckDocumentRepository.getDocumentTypeByTruckIds(truckIds);
+        Map<String, List<TruckDocumentInfoDto>> documents = truckDocumentRepository.getDocumentTypeByTruckIds(truckIds);
         return trucks.map(truck -> {
             List<String> regionNames = truck.getTruckRegionNames(regionSearchProcessor);
             String regionList = truckRegionFullNameGenerator.makeRegionListByRegionNames(regionNames);


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #212

## 📝작업 내용

> 행사 목록 조회 api 수정, 트럭 목록 조회 및 상세 조회 api에 사업자등록증 인증 여부 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
