### PR TITLE
🐛 반려된 사업자등록증 재등록 시 대기 상태로 초기화되도록 수정

### DIFF
--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/application/service/TruckService.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/application/service/TruckService.java
@@ -397,6 +397,7 @@ public class TruckService {
                     if (dto.getFileIdList() != null && !dto.getFileIdList().isEmpty()) {
                         saveTruckDocumentPhotos(dto.getFileIdList(), existingDoc, memberId);
                     }
+                    existingDoc.resubmit(memberId);
                     existingDoc.update(LocalDateTime.now(), memberId);
                     truckDocumentRepository.save(existingDoc);
                 }

--- a/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckDocument.java
+++ b/src/main/java/com/barowoori/foodpinbackend/truck/command/domain/model/TruckDocument.java
@@ -99,4 +99,11 @@ public class TruckDocument {
         this.rejectionReason = rejectionReason;
         this.processedAt = LocalDateTime.now();
     }
+
+    public void resubmit(String updatedBy) {
+        this.updatedBy = updatedBy;
+        this.status = TruckDocumentStatus.PENDING;
+        this.rejectionReason = null;
+        this.processedAt = null;
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #219 

## 📝작업 내용

> 반려된 사업자등록증 재등록 시 대기 상태로 초기화되도록 수정