### PR TITLE
✨ 행사 운영시간 직접입력(String) 방식 추가

### DIFF
--- a/src/main/java/com/barowoori/foodpinbackend/event/command/application/dto/RequestEvent.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/application/dto/RequestEvent.java
@@ -24,6 +24,18 @@ import java.util.List;
 import java.util.Set;
 
 public class RequestEvent {
+    private static boolean isValidOperatingTime(String operatingTime, List<EventDateDto> eventDateDtoList) {
+        boolean hasOperatingTime = operatingTime != null && !operatingTime.isBlank();
+        boolean allHaveTime = eventDateDtoList != null && !eventDateDtoList.isEmpty()
+                && eventDateDtoList.stream().allMatch(d -> d.getStartTime() != null && d.getEndTime() != null);
+        boolean anyHasTime = eventDateDtoList != null
+                && eventDateDtoList.stream().anyMatch(d -> d.getStartTime() != null || d.getEndTime() != null);
+        if (hasOperatingTime) {
+            return !anyHasTime;
+        }
+        return allHaveTime;
+    }
+
     @Builder
     @Data
     @Getter
@@ -91,6 +103,16 @@ public class RequestEvent {
         @Valid
         private List<EventDateDto> eventDateDtoList;
 
+        @UnicodeSize(max = 50, message = "50자 이하로 입력하세요.")
+        @Schema(description = "운영시간 직접입력(행사 전체), 날짜별 시간 미입력 시 필수")
+        private String operatingTime;
+
+        @JsonIgnore
+        @AssertTrue(message = "운영시간을 직접 입력하거나 모든 날짜에 시작/종료 시간을 입력해야 합니다. (둘 중 하나만)")
+        public boolean isValidOperatingTime() {
+            return RequestEvent.isValidOperatingTime(this.operatingTime, this.eventDateDtoList);
+        }
+
         public Event toEntity(String creator) {
             return Event.builder()
                     .createdBy(creator)
@@ -105,6 +127,7 @@ public class RequestEvent {
                     .saleType(null)
                     .priceRange(null)
                     .cateringDetail(null)
+                    .operatingTime(this.operatingTime)
                     .isDeleted(Boolean.FALSE)
                     .build();
         }
@@ -140,6 +163,16 @@ public class RequestEvent {
         @NotEmpty
         private String recruitmentUrl;
 
+        @UnicodeSize(max = 50, message = "50자 이하로 입력하세요.")
+        @Schema(description = "운영시간 직접입력(행사 전체), 날짜별 시간 미입력 시 필수")
+        private String operatingTime;
+
+        @JsonIgnore
+        @AssertTrue(message = "운영시간을 직접 입력하거나 모든 날짜에 시작/종료 시간을 입력해야 합니다. (둘 중 하나만)")
+        public boolean isValidOperatingTime() {
+            return RequestEvent.isValidOperatingTime(this.operatingTime, this.eventDateDtoList);
+        }
+
         public Event toEntity(String creator) {
             return Event.builder()
                     .createdBy(creator)
@@ -155,6 +188,7 @@ public class RequestEvent {
                     .priceRange(null)
                     .cateringDetail(null)
                     .recruitmentUrl(this.recruitmentUrl)
+                    .operatingTime(this.operatingTime)
                     .isDeleted(Boolean.FALSE)
                     .build();
         }
@@ -262,12 +296,10 @@ public class RequestEvent {
         @NotNull
         private LocalDate date;
 
-        @Schema(description = "시작 시간", example = "09:00:00")
-        @NotNull
+        @Schema(description = "시작 시간, 운영시간 직접입력 시 미입력", example = "09:00:00")
         private LocalTime startTime;
 
-        @Schema(description = "종료 시간", example = "20:00:00")
-        @NotNull
+        @Schema(description = "종료 시간, 운영시간 직접입력 시 미입력", example = "20:00:00")
         private LocalTime endTime;
 
         public EventDate toEntity(Event event) {
@@ -298,11 +330,22 @@ public class RequestEvent {
         private List<String> fileIdList;
 
         @NotEmpty
+        @Valid
         private List<EventDateDto> eventDateDtoList;
 
         @Schema(description = "행사 지역 코드", example = "GU85")
         @NotEmpty
         private String regionCode;
+
+        @UnicodeSize(max = 50, message = "50자 이하로 입력하세요.")
+        @Schema(description = "운영시간 직접입력(행사 전체), 날짜별 시간 미입력 시 필수")
+        private String operatingTime;
+
+        @JsonIgnore
+        @AssertTrue(message = "운영시간을 직접 입력하거나 모든 날짜에 시작/종료 시간을 입력해야 합니다. (둘 중 하나만)")
+        public boolean isValidOperatingTime() {
+            return RequestEvent.isValidOperatingTime(this.operatingTime, this.eventDateDtoList);
+        }
     }
 
     @Getter

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventService.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventService.java
@@ -193,12 +193,12 @@ public class EventService {
         event.initEventRegion(eventRegion);
 
         if (Objects.equals(eventRecruitDto.getRecruitEndDateTime(), null)) {
-            LocalDateTime lastEndDateTime = eventDateDtoList.stream()
-                    .map(dto -> LocalDateTime.of(dto.getDate(), dto.getEndTime()))
-                    .max(LocalDateTime::compareTo)
+            LocalDate lastDate = eventDateDtoList.stream()
+                    .map(RequestEvent.EventDateDto::getDate)
+                    .max(LocalDate::compareTo)
                     .orElseThrow(() -> new CustomException(EventErrorCode.EVENT_DATE_NOT_FOUND));
 
-            eventRecruitDto.setRecruitEndDateTime(lastEndDateTime.toLocalDate().atTime(23, 59, 59));
+            eventRecruitDto.setRecruitEndDateTime(lastDate.atTime(23, 59, 59));
         }
         EventRecruitDetail eventRecruitDetail = eventRecruitDto.toEntity(
                 event,
@@ -241,7 +241,8 @@ public class EventService {
         event.updateBasicInfo(
                 updateEventInfoDto.getName(),
                 updateEventInfoDto.getType(),
-                updateEventInfoDto.getExpectedParticipants()
+                updateEventInfoDto.getExpectedParticipants(),
+                updateEventInfoDto.getOperatingTime()
         );
 
         List<EventPhoto> photoList = eventPhotoRepository.findAllByEvent(event);
@@ -286,12 +287,12 @@ public class EventService {
         if (eventRecruitDetail == null)
             throw new CustomException(EventErrorCode.EVENT_RECRUIT_DETAIL_NOT_FOUND);
         if (Objects.equals(eventRecruitDto.getRecruitEndDateTime(), null)) {
-            LocalDateTime lastEndDateTime = event.getEventDates().stream()
-                    .map(eventDate -> LocalDateTime.of(eventDate.getDate(), eventDate.getEndTime()))
-                    .max(LocalDateTime::compareTo)
+            LocalDate lastDate = event.getEventDates().stream()
+                    .map(EventDate::getDate)
+                    .max(LocalDate::compareTo)
                     .orElseThrow(() -> new CustomException(EventErrorCode.EVENT_DATE_NOT_FOUND));
 
-            eventRecruitDto.setRecruitEndDateTime(lastEndDateTime.toLocalDate().atTime(23, 59, 59));
+            eventRecruitDto.setRecruitEndDateTime(lastDate.atTime(23, 59, 59));
         }
         eventRecruitDetail.update(
                 eventRecruitDto.getRecruitEndDateTime(),

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventStatusUpdater.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/application/service/EventStatusUpdater.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -39,11 +40,11 @@ public class EventStatusUpdater {
                 closeRecruiting(event);
             }
 
-            LocalDateTime eventEndDateTime = event.getEventDates().stream()
-                    .map(eventDate -> LocalDateTime.of(eventDate.getDate(), eventDate.getEndTime()))
-                    .max(LocalDateTime::compareTo)
+            LocalDate eventEndDate = event.getEventDates().stream()
+                    .map(EventDate::getDate)
+                    .max(LocalDate::compareTo)
                     .orElse(null);
-            boolean isEventEnded = eventEndDateTime != null && eventEndDateTime.toLocalDate().atTime(23, 59, 59).isBefore(now);
+            boolean isEventEnded = eventEndDate != null && eventEndDate.atTime(23, 59, 59).isBefore(now);
 
             if (isEventEnded) {
                 closeSelection(event);

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/model/Event.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/model/Event.java
@@ -96,6 +96,9 @@ public class Event {
     @Column(name = "expected_participants")
     private String expectedParticipants;
 
+    @Column(name = "operating_time", length = 50)
+    private String operatingTime;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "sale_type")
     private SaleType saleType;
@@ -137,7 +140,7 @@ public class Event {
                  EventDocumentSubmissionTarget documentSubmissionTarget, String submissionEmail, EventType type,
                  String expectedParticipants, Set<TruckType> truckTypes, SaleType saleType,
                  PriceRange priceRange, String cateringDetail, String contact,
-                 String recruitmentUrl, int recruitmentUrlClickCount) {
+                 String recruitmentUrl, int recruitmentUrlClickCount, String operatingTime) {
         this.createdBy = createdBy;
         this.creatorType = creatorType;
         this.name = name;
@@ -156,12 +159,14 @@ public class Event {
         this.recruitmentUrl = recruitmentUrl;
         this.recruitmentUrlClickCount = recruitmentUrlClickCount;
         this.isHidden = false;
+        this.operatingTime = operatingTime;
     }
 
-    public void updateBasicInfo(String name, EventType type, String expectedParticipants) {
+    public void updateBasicInfo(String name, EventType type, String expectedParticipants, String operatingTime) {
         this.name = name;
         this.type = type;
         this.expectedParticipants = expectedParticipants;
+        this.operatingTime = operatingTime;
     }
 
     public void updateDetailInfo(String description, String guidelines, String contact) {

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventAppliedTruckDetail.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventAppliedTruckDetail.java
@@ -28,6 +28,7 @@ public class EventAppliedTruckDetail extends TruckDetail {
     private Boolean isFullAttendanceRequired;
     private EventApplicationStatus status;
     private List<EventDetail.EventDateInfo> dates;
+    private String operatingTime;
 
     public static EventAppliedTruckDetail of(EventApplication eventApplication, Truck truck, TruckDocumentManager truckDocumentManager, List<RegionCode> regions, String regionList, List<Category> categories, List<TruckMenu> truckMenus, ImageManager imageManager) {
         return EventAppliedTruckDetail.builder()
@@ -52,6 +53,7 @@ public class EventAppliedTruckDetail extends TruckDetail {
                 .status(eventApplication.getStatus())
                 .dates(eventApplication.getSortedEventDates().stream()
                         .map(EventDateInfo::of).toList())
+                .operatingTime(eventApplication.getEvent().getOperatingTime())
                 .regionList(regionList)
                 .build();
     }

--- a/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventDetail.java
+++ b/src/main/java/com/barowoori/foodpinbackend/event/command/domain/repository/dto/EventDetail.java
@@ -52,6 +52,7 @@ public class EventDetail {
     private String submissionEmail;
     private Boolean isRecruitEndOnSelection;
     private LocalDateTime recruitEndDateTime;
+    private String operatingTime;
 
     public static EventDetail of(Event event, String memberId, Boolean isLike, ImageManager imageManager, List<RegionCode> regions, String regionList) {
         return EventDetail.builder()
@@ -87,6 +88,7 @@ public class EventDetail {
                 .submissionEmail(event.getSubmissionEmail())
                 .recruitEndDateTime(event.getRecruitDetail().getRecruitEndDateTime())
                 .isRecruitEndOnSelection(event.getRecruitDetail().getIsRecruitEndOnSelection())
+                .operatingTime(event.getOperatingTime())
                 .build();
 
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #272 

## 📝작업 내용

> 운영시간을 날짜별 시작/종료 시간 또는 행사 전체 단일 문자열(최대 50자) 중 하나로 입력
> EventDate startTime/endTime nullable 전환, Event에 operatingTime 컬럼 추가
> 입력 검증: 둘 중 정확히 하나(날짜별은 전부 or 전무)
> 모집마감/행사종료 계산을 시간 무관 날짜 기준으로 null-safe 처리
> 행사 상세/지원행사 상세 응답에 operatingTime 추가