### PR TITLE
Enable HTTP request histograms for p95 monitoring

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -126,6 +126,9 @@ jobs:
           echo "  metrics:" >> ${APP_CONFIG_FILE}
           echo "    tags:" >> ${APP_CONFIG_FILE}
           echo "      application: ${SERVICE}-${PROFILE}" >> ${APP_CONFIG_FILE}
+          echo "    distribution:" >> ${APP_CONFIG_FILE}
+          echo "      percentiles-histogram:" >> ${APP_CONFIG_FILE}
+          echo "        http.server.requests: true" >> ${APP_CONFIG_FILE}
 
       # application-S3.properties 생성
       - name: Create aws-s3-config.yml


### PR DESCRIPTION
Enables the Spring Boot production metric histogram for http.server.requests. This emits the bucket metrics required by the existing Grafana API p95 panel. Scope: CD workflow configuration only; no Grafana, Prometheus, or server configuration files are included in this PR. Deployment runs when this change is merged into main. Local Gradle tests have 5 existing unrelated failures in ordering/search tests.