### PR TITLE
Enable OpenTelemetry tracing and Prometheus exemplars

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -261,5 +261,14 @@ jobs:
             --name ${{env.SERVICE}}-${{env.PROFILE}} \
             --network barowoori-net \
             -p ${PORT}:8080 \
+            --restart unless-stopped \
             -e SPRING_PROFILES_ACTIVE=${{env.PROFILE}} \
+            -e OTEL_SDK_DISABLED=false \
+            -e OTEL_SERVICE_NAME=${{env.SERVICE}}-${{env.PROFILE}} \
+            -e OTEL_EXPORTER_OTLP_ENDPOINT=http://tempo:4318 \
+            -e OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+            -e OTEL_TRACES_SAMPLER=always_on \
+            -e OTEL_METRICS_EXPORTER=none \
+            -e OTEL_LOGS_EXPORTER=none \
+            -e OTEL_RESOURCE_ATTRIBUTES=deployment.environment.name=${{env.PROFILE}} \
             ${{ env.ECR_URI }}:${{env.PROFILE}}-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,15 @@
 FROM eclipse-temurin:21-jdk
 ENV TZ=Asia/Seoul
-RUN apt-get update && apt-get install -y tzdata && \
+ARG OTEL_JAVA_AGENT_VERSION=2.29.0
+ARG OTEL_JAVA_AGENT_SHA256=546531ca690a8603d2923b6db26bbda35c6409327b1e610430ae33c2f8f68050
+RUN apt-get update && apt-get install -y tzdata curl && \
     ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+    mkdir -p /opt/opentelemetry && \
+    curl --fail --location --silent --show-error "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_JAVA_AGENT_VERSION}/opentelemetry-javaagent.jar" --output /opt/opentelemetry/opentelemetry-javaagent.jar && \
+    echo "${OTEL_JAVA_AGENT_SHA256}  /opt/opentelemetry/opentelemetry-javaagent.jar" | sha256sum --check --strict && \
     rm -rf /var/lib/apt/lists/*
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENV SPRING_PROFILES_ACTIVE=dev
-CMD ["sh", "-c", "java -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE} -jar app.jar"]
+ENV OTEL_SDK_DISABLED=true
+CMD ["sh", "-c", "java -javaagent:/opt/opentelemetry/opentelemetry-javaagent.jar -Xlog:gc*:stdout:time,level,tags -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE} -jar app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
 	// prometheus
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'io.opentelemetry:opentelemetry-api:1.64.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/barowoori/foodpinbackend/config/PrometheusExemplarConfig.java
+++ b/src/main/java/com/barowoori/foodpinbackend/config/PrometheusExemplarConfig.java
@@ -1,0 +1,37 @@
+package com.barowoori.foodpinbackend.config;
+
+import io.opentelemetry.api.trace.Span;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class PrometheusExemplarConfig {
+
+    @Bean
+    public io.prometheus.metrics.tracer.common.SpanContext prometheusSpanContext() {
+        return new io.prometheus.metrics.tracer.common.SpanContext() {
+            @Override
+            public String getCurrentTraceId() {
+                return Span.current().getSpanContext().getTraceId();
+            }
+
+            @Override
+            public String getCurrentSpanId() {
+                return Span.current().getSpanContext().getSpanId();
+            }
+
+            @Override
+            public boolean isCurrentSpanSampled() {
+                return Span.current().getSpanContext().isSampled();
+            }
+
+            @Override
+            public void markCurrentSpanAsExemplar() {
+                Span.current().setAttribute(
+                    io.prometheus.metrics.tracer.common.SpanContext.EXEMPLAR_ATTRIBUTE_NAME,
+                    io.prometheus.metrics.tracer.common.SpanContext.EXEMPLAR_ATTRIBUTE_VALUE
+                );
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 변경 내용

- OpenTelemetry Java Agent 2.29.0을 애플리케이션 이미지에 포함하고 SHA-256을 검증합니다.
- 운영 컨테이너에서 OTLP/HTTP로 내부 Tempo 엔드포인트에 Trace를 전송합니다.
- HTTP, JDBC, 외부 HTTP 호출 자동 계측을 100% 샘플링으로 시작합니다.
- Prometheus exemplar가 현재 Trace ID와 Span ID를 참조할 수 있도록 `SpanContext`를 연결합니다.
- JVM GC 로그를 표준 출력에 활성화하고 컨테이너 재시작 정책을 추가합니다.

## 이유와 영향

Grafana에서 느린 API를 찾은 뒤 실제 요청의 HTTP/JDBC/외부 호출 구간을 Tempo에서 확인하고, Prometheus latency 측정값에서 관련 Trace로 이동하기 위한 변경입니다. Metrics와 logs는 기존 방식만 사용하고 OpenTelemetry Agent에서는 내보내지 않아 중복 수집을 피합니다.

## 검증

- `./gradlew compileJava` 성공
- `./gradlew bootJar -x test` 성공
- 전체 테스트 86개 중 기존과 동일한 정렬/시간 경계 테스트 5개 실패, OpenTelemetry 변경으로 인한 신규 실패 없음
- Dockerfile의 Agent 버전 및 SHA-256을 공식 GitHub 릴리스 자산과 대조
- 로컬 Docker 엔진이 실행 중이 아니어서 로컬 이미지 빌드는 수행하지 못했으며, CI Docker build에서 최종 확인 예정
