### PR TITLE
요청 Trace 원클릭 탐색과 운영 상태 대시보드 통합

### DIFF
--- a/monitoring/grafana/dashboards/foodpin-request-explorer.json
+++ b/monitoring/grafana/dashboards/foodpin-request-explorer.json
@@ -10,18 +10,410 @@
   "links": [
     {
       "asDropdown": false,
-      "icon": "external link",
+      "icon": "bell",
       "includeVars": false,
       "keepTime": true,
       "tags": [],
       "targetBlank": false,
-      "title": "Runtime Health 보기",
-      "tooltip": "JVM, GC, HikariCP 등 운영 상태 대시보드로 이동합니다.",
+      "title": "알림 규칙 보기",
+      "tooltip": "현재 알림 상태와 규칙을 확인합니다.",
       "type": "link",
-      "url": "/d/foodpin-api-overview/foodpin-operations-overview"
+      "url": "/alerting/list"
     }
   ],
   "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Prometheus가 Foodpin 애플리케이션 메트릭을 정상 수집 중인지 보여줍니다.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(up{job=\"spring-boot\"}) or vector(0)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Service UP",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Prometheus 규칙 중 현재 firing 상태인 알림 개수입니다. 0이 아니면 상단의 알림 규칙 보기를 확인합니다.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "count(ALERTS{alertstate=\"firing\"}) or vector(0)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Firing alerts",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "전체 API의 최근 5분 5xx 비율입니다. 요청이 없거나 5xx가 없으면 0%로 표시합니다.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 12,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum(rate(http_server_requests_seconds_count{job=\"spring-boot\",status=~\"5..\",method!=\"OPTIONS\",uri!~\"/actuator.*|UNKNOWN\"}[5m])) / sum(rate(http_server_requests_seconds_count{job=\"spring-boot\",method!=\"OPTIONS\",uri!~\"/actuator.*|UNKNOWN\"}[5m]))) or vector(0)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx rate · recent 5m",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "현재 사용 중인 DB 커넥션 / 최대 커넥션 비율입니다.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 13,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(hikaricp_connections_active{job=\"spring-boot\"}) / sum(hikaricp_connections_max{job=\"spring-boot\"})",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Hikari utilization · now",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "현재 JVM Heap 사용량 / 최대 Heap 비율입니다.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.85
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(jvm_memory_used_bytes{job=\"spring-boot\",area=\"heap\"}) / sum(jvm_memory_max_bytes{job=\"spring-boot\",area=\"heap\"})",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "JVM heap usage · now",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "최근 15분에 관측된 JVM GC pause 최대값입니다. 1초 이상이면 알림 규칙과 같은 시점을 확인합니다.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(max_over_time(jvm_gc_pause_seconds_max{job=\"spring-boot\"}[15m])) or vector(0)",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "GC max pause · recent 15m",
+      "type": "stat"
+    },
     {
       "datasource": {
         "type": "grafana",
@@ -29,10 +421,10 @@
       },
       "description": "이 화면은 통계보다 실제 요청 한 건을 찾고 추적하는 데 집중합니다.",
       "gridPos": {
-        "h": 3,
+        "h": 2,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 4
       },
       "id": 1,
       "options": {
@@ -133,7 +525,23 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 190
+                "value": 170
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "Trace 상세 열기",
+                    "url": "/explore?left=%7B%22range%22%3A%7B%22from%22%3A%22${__from}%22%2C%22to%22%3A%22${__to}%22%7D%2C%22datasource%22%3A%22tempo%22%2C%22queries%22%3A%5B%7B%22query%22%3A%22${__value.raw}%22%2C%22queryType%22%3A%22traceql%22%2C%22datasource%22%3A%7B%22uid%22%3A%22tempo%22%7D%7D%5D%7D"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "data-links"
+                }
               }
             ]
           }
@@ -143,7 +551,7 @@
         "h": 12,
         "w": 12,
         "x": 0,
-        "y": 3
+        "y": 6
       },
       "id": 2,
       "options": {
@@ -180,7 +588,7 @@
               "kind": true,
               "name": true,
               "service.name": true,
-              "traceIdHidden": true,
+              "spanID": true,
               "traceName": true,
               "traceService": true
             },
@@ -189,7 +597,7 @@
               "http.request.method": 1,
               "http.response.status_code": 3,
               "http.route": 2,
-              "spanID": 5,
+              "traceIdHidden": 5,
               "time": 0
             },
             "renameByName": {
@@ -197,7 +605,7 @@
               "http.request.method": "Method",
               "http.response.status_code": "Status",
               "http.route": "API",
-              "spanID": "Trace 열기",
+              "traceIdHidden": "Trace 열기",
               "time": "Time"
             }
           }
@@ -316,7 +724,23 @@
             "properties": [
               {
                 "id": "custom.width",
-                "value": 190
+                "value": 170
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": false,
+                    "title": "Trace 상세 열기",
+                    "url": "/explore?left=%7B%22range%22%3A%7B%22from%22%3A%22${__from}%22%2C%22to%22%3A%22${__to}%22%7D%2C%22datasource%22%3A%22tempo%22%2C%22queries%22%3A%5B%7B%22query%22%3A%22${__value.raw}%22%2C%22queryType%22%3A%22traceql%22%2C%22datasource%22%3A%7B%22uid%22%3A%22tempo%22%7D%7D%5D%7D"
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "data-links"
+                }
               }
             ]
           }
@@ -326,7 +750,7 @@
         "h": 12,
         "w": 12,
         "x": 12,
-        "y": 3
+        "y": 6
       },
       "id": 3,
       "options": {
@@ -363,7 +787,7 @@
               "kind": true,
               "name": true,
               "service.name": true,
-              "traceIdHidden": true,
+              "spanID": true,
               "traceName": true,
               "traceService": true
             },
@@ -372,7 +796,7 @@
               "http.request.method": 1,
               "http.response.status_code": 3,
               "http.route": 2,
-              "spanID": 5,
+              "traceIdHidden": 5,
               "time": 0
             },
             "renameByName": {
@@ -380,7 +804,7 @@
               "http.request.method": "Method",
               "http.response.status_code": "Status",
               "http.route": "API",
-              "spanID": "Trace 열기",
+              "traceIdHidden": "Trace 열기",
               "time": "Time"
             }
           }
@@ -434,7 +858,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 18
       },
       "id": 4,
       "options": {

--- a/monitoring/grafana/dashboards/foodpin-request-explorer.json
+++ b/monitoring/grafana/dashboards/foodpin-request-explorer.json
@@ -1,0 +1,677 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Low-traffic friendly API request explorer backed by Tempo traces and Prometheus summaries.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Runtime Health 보기",
+      "tooltip": "JVM, GC, HikariCP 등 운영 상태 대시보드로 이동합니다.",
+      "type": "link",
+      "url": "/d/foodpin-api-overview/foodpin-operations-overview"
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana",
+        "uid": "-- Grafana --"
+      },
+      "description": "이 화면은 통계보다 실제 요청 한 건을 찾고 추적하는 데 집중합니다.",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "### 보는 순서\n1. **Recent API Requests**에서 실제 요청을 확인합니다.  \n2. 느린 요청은 **Slow Requests**에서 처리시간 순으로 찾습니다.  \n3. 해당 행의 **Trace 열기**를 누르면 Controller/Repository/DB/외부 호출 흐름이 Tempo에서 열립니다.  \n요청 한 건도 숨기지 않으며, 우측 상단 시간 범위를 바꾸면 과거 요청도 조회할 수 있습니다.",
+        "mode": "markdown"
+      },
+      "pluginVersion": "13.0.2",
+      "title": "사용 방법",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "description": "선택한 시간 범위에 발생한 API 요청을 최신순으로 표시합니다. Trace 열기를 누르면 해당 요청의 전체 처리 흐름이 열립니다.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "API"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 330
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 400
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trace 열기"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 190
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 3
+      },
+      "id": 2,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Time"
+          }
+        ]
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "limit": 100,
+          "query": "{ resource.service.name = \"foodpin-backend-prod\" && span:kind = server && span:name =~ \"${method} ${api}\" } | select(span.http.request.method, span.http.route, span.http.response.status_code)",
+          "queryType": "traceql",
+          "refId": "A",
+          "spanLimit": 3,
+          "tableType": "spans"
+        }
+      ],
+      "title": "Recent API Requests · selected range",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "kind": true,
+              "name": true,
+              "service.name": true,
+              "traceIdHidden": true,
+              "traceName": true,
+              "traceService": true
+            },
+            "indexByName": {
+              "duration": 4,
+              "http.request.method": 1,
+              "http.response.status_code": 3,
+              "http.route": 2,
+              "spanID": 5,
+              "time": 0
+            },
+            "renameByName": {
+              "duration": "Duration",
+              "http.request.method": "Method",
+              "http.response.status_code": "Status",
+              "http.route": "API",
+              "spanID": "Trace 열기",
+              "time": "Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "tempo",
+        "uid": "tempo"
+      },
+      "description": "선택한 시간 범위에서 기준 시간보다 오래 걸린 실제 요청을 처리시간이 긴 순서로 표시합니다. 요청 수 최소 조건은 없습니다.",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "API"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 330
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Status"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 0
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 400
+                    },
+                    {
+                      "color": "red",
+                      "value": 500
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Duration"
+            },
+            "properties": [
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "yellow",
+                      "value": 500000000
+                    },
+                    {
+                      "color": "red",
+                      "value": 2000000000
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trace 열기"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 190
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 3
+      },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Duration"
+          }
+        ]
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "tempo",
+            "uid": "tempo"
+          },
+          "limit": 100,
+          "query": "{ resource.service.name = \"foodpin-backend-prod\" && span:kind = server && span:name =~ \"${method} ${api}\" && span:duration > ${slow} } | select(span.http.request.method, span.http.route, span.http.response.status_code)",
+          "queryType": "traceql",
+          "refId": "A",
+          "spanLimit": 3,
+          "tableType": "spans"
+        }
+      ],
+      "title": "Slow Requests · slower than $slow",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "kind": true,
+              "name": true,
+              "service.name": true,
+              "traceIdHidden": true,
+              "traceName": true,
+              "traceService": true
+            },
+            "indexByName": {
+              "duration": 4,
+              "http.request.method": 1,
+              "http.response.status_code": 3,
+              "http.route": 2,
+              "spanID": 5,
+              "time": 0
+            },
+            "renameByName": {
+              "duration": "Duration",
+              "http.request.method": "Method",
+              "http.response.status_code": "Status",
+              "http.route": "API",
+              "spanID": "Trace 열기",
+              "time": "Time"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "선택한 시간 범위의 API별 요청 수와 응답시간 요약입니다. 요청 수가 한 건이어도 숨기지 않으며, p95/p99는 반드시 Requests와 함께 해석합니다.",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Requests"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals",
+                "value": 0
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "API"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 420
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Requests"
+          }
+        ]
+      },
+      "pluginVersion": "13.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "round(sum by(uri,method)(increase(http_server_requests_seconds_count{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range]))) > 0",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum by(uri,method)(increase(http_server_requests_seconds_sum{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range])) / clamp_min(sum by(uri,method)(increase(http_server_requests_seconds_count{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range])), 1)) and on(uri,method) (sum by(uri,method)(increase(http_server_requests_seconds_count{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range])) > 0)",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max by(uri,method)(max_over_time(http_server_requests_seconds_max{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range])) and on(uri,method) (sum by(uri,method)(increase(http_server_requests_seconds_count{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range])) > 0)",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.95,sum by(le,uri,method)(increase(http_server_requests_seconds_bucket{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range]))) and on(uri,method) (sum by(uri,method)(increase(http_server_requests_seconds_count{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range])) > 0)",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "histogram_quantile(0.99,sum by(le,uri,method)(increase(http_server_requests_seconds_bucket{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range]))) and on(uri,method) (sum by(uri,method)(increase(http_server_requests_seconds_count{job=\"spring-boot\",method=~\"${method}\",method!=\"OPTIONS\",uri=~\"${api}\",uri!~\"/actuator.*|UNKNOWN\"}[$__range])) > 0)",
+          "format": "table",
+          "instant": true,
+          "range": false,
+          "refId": "E"
+        }
+      ],
+      "title": "API Summary · selected range · no minimum traffic",
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true
+            },
+            "indexByName": {
+              "Value #A": 2,
+              "Value #B": 3,
+              "Value #C": 4,
+              "Value #D": 5,
+              "Value #E": 6,
+              "method": 0,
+              "uri": 1
+            },
+            "renameByName": {
+              "Value #A": "Requests",
+              "Value #B": "Average",
+              "Value #C": "Max",
+              "Value #D": "p95",
+              "Value #E": "p99",
+              "method": "Method",
+              "uri": "API"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "foodpin",
+    "requests",
+    "traces"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Method",
+        "multi": false,
+        "name": "method",
+        "options": [
+          {
+            "selected": true,
+            "text": "All",
+            "value": "$__all"
+          },
+          {
+            "selected": false,
+            "text": "GET",
+            "value": "GET"
+          },
+          {
+            "selected": false,
+            "text": "POST",
+            "value": "POST"
+          },
+          {
+            "selected": false,
+            "text": "PUT",
+            "value": "PUT"
+          },
+          {
+            "selected": false,
+            "text": "PATCH",
+            "value": "PATCH"
+          },
+          {
+            "selected": false,
+            "text": "DELETE",
+            "value": "DELETE"
+          }
+        ],
+        "query": "GET,POST,PUT,PATCH,DELETE",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "text": "/api/.*",
+          "value": "/api/.*"
+        },
+        "hide": 0,
+        "label": "API regex",
+        "name": "api",
+        "options": [
+          {
+            "selected": true,
+            "text": "/api/.*",
+            "value": "/api/.*"
+          }
+        ],
+        "query": "/api/.*",
+        "skipUrlSync": false,
+        "type": "textbox"
+      },
+      {
+        "current": {
+          "text": "500ms",
+          "value": "500ms"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Slow 기준",
+        "multi": false,
+        "name": "slow",
+        "options": [
+          {
+            "selected": false,
+            "text": "100ms",
+            "value": "100ms"
+          },
+          {
+            "selected": false,
+            "text": "300ms",
+            "value": "300ms"
+          },
+          {
+            "selected": true,
+            "text": "500ms",
+            "value": "500ms"
+          },
+          {
+            "selected": false,
+            "text": "1s",
+            "value": "1s"
+          },
+          {
+            "selected": false,
+            "text": "2s",
+            "value": "2s"
+          },
+          {
+            "selected": false,
+            "text": "5s",
+            "value": "5s"
+          }
+        ],
+        "query": "100ms,300ms,500ms,1s,2s,5s",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Foodpin Request Explorer",
+  "uid": "foodpin-request-explorer",
+  "version": 1,
+  "weekStart": ""
+}


### PR DESCRIPTION
## 변경 내용

- `Foodpin Request Explorer` 한 화면에 요청 탐색과 최소 운영 상태를 통합했습니다.
- `Recent API Requests`와 `Slow Requests`의 `Trace 상세 열기`가 실제 Trace ID를 사용하도록 수정했습니다.
- 서비스 수집, firing 알림 수, 5xx, Hikari, JVM Heap, GC pause만 상단 상태 카드로 추가했습니다.
- 개별 요청 목록과 API Summary는 기존처럼 최소 요청 수 조건 없이 유지했습니다.
- 별도 Operations Overview 링크를 제거하고 Grafana Alerting 링크로 교체했습니다.

## 원인과 수정

기존 링크는 표 변환 단계에서 숨겨진 `traceIdHidden` 필드를 제거한 뒤 Span ID 자동 링크를 사용했습니다. 이 때문에 Explore URL의 Trace 쿼리가 비어 `No data`가 표시됐습니다.

이제 숨겨진 실제 Trace ID를 `Trace 상세 열기` 필드로 사용하고, 선택한 대시보드 시간 범위와 Trace ID를 Explore URL에 직접 전달합니다. 느린 요청 행에서 링크를 한 번 누르면 별도 검색 없이 해당 Trace 상세가 열립니다.

## 영향 범위

- 저장소 변경 파일은 `monitoring/grafana/dashboards/foodpin-request-explorer.json` 1개입니다.
- 애플리케이션 코드, CD 파이프라인, DB 설정은 변경하지 않습니다.
- 운영 Grafana에서는 기존 `Foodpin Operations Overview`를 제거해 Foodpin 대시보드를 Request Explorer 하나로 정리했습니다.

## 검증

- JSON 파싱 및 `git diff --check` 통과
- 새 운영 상태 PromQL 6개 모두 Grafana datasource API 응답 확인
- Tempo TraceQL 최근 요청 100건 응답 확인
- Grafana 13.0.2 프로비저닝과 10개 패널 로드 확인
- 실제 브라우저에서 `Slow Requests → POST /api/members/v2/login → Trace 상세 열기` 1회 클릭 검증
- 클릭 후 5.14초 Trace 상세, Repository/SQL/외부 GET span 표시 및 `No data` 미발생 확인
- 기존 Operations Overview UID 조회 404, Foodpin 폴더에는 Request Explorer만 존재함을 확인
